### PR TITLE
Add nuxtjs hello world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Hello World with Nuxt
+
+This repo is forked from [nuxt.js/examples/hello-world](https://github.com/nuxt/nuxt.js/tree/dev/examples/hello-world).
+
+The app in this repo is deployed at https://nuxt-js.onrender.com.
+
+## Deploy
+
+Click the button below to deploy this app on Render.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ The app in this repo is deployed at [https://nuxtjs.onrender.com](https://nuxtjs
 ## Deployment
 
 See https://render.com/docs/deploy-nuxtjs for quick and easy deployment instructions.
+
+Use the `main` branch of this repository for deploying as a `Node` app and the `static` branch for deploying as a static site.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# Hello World with Nuxt
+# README
 
-This repo is forked from [nuxt.js/examples/hello-world](https://github.com/nuxt/nuxt.js/tree/dev/examples/hello-world).
+This is the [NuxtJS](https://nuxtjs.org/) [Hello world](https://github.com/nuxt/nuxt.js/tree/dev/examples/hello-world) example on [Render](https://render.com).
 
-The app in this repo is deployed at https://nuxt-js.onrender.com.
+The app in this repo is deployed at [https://nuxtjs.onrender.com](https://express.onrender.com).
 
-## Deploy
+## Deployment
 
-Click the button below to deploy this app on Render.
-
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
-
+See https://render.com/docs/deploy-nuxtjs for quick and easy deployment instructions.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the [NuxtJS](https://nuxtjs.org/) [Hello world](https://github.com/nuxt/nuxt.js/tree/dev/examples/hello-world) example on [Render](https://render.com).
 
-The app in this repo is deployed at [https://nuxtjs.onrender.com](https://express.onrender.com).
+The app in this repo is deployed at [https://nuxtjs.onrender.com](https://nuxtjs.onrender.com).
 
 ## Deployment
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,0 +1,8 @@
+export default {
+  server: {
+    host: '0.0.0.0' // default: localhost
+  }
+  // Uncomment the following to deploy as a static site on Render
+  // target: 'static'
+}
+

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,7 +2,5 @@ export default {
   server: {
     host: '0.0.0.0' // default: localhost
   }
-  // Uncomment the following to deploy as a static site on Render
-  // target: 'static'
 }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,6 @@
 export default {
   server: {
-    host: '0.0.0.0' // default: localhost
+    host: '0.0.0.0'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "example-hello-world",
+  "dependencies": {
+    "nuxt": "latest"
+  },
+  "scripts": {
+    "dev": "nuxt",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "generate": "nuxt generate"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "nuxt",
     "build": "nuxt build",
-    "start": "nuxt start",
-    "generate": "nuxt generate"
+    "start": "nuxt start"
   }
 }

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <p>Hi from {{ name }}</p>
+    <NLink to="/">
+      Home page
+    </NLink>
+  </div>
+</template>
+
+<script>
+export default {
+  asyncData () {
+    return {
+      name: process.static ? 'static' : (process.server ? 'server' : 'client')
+    }
+  },
+  head: {
+    title: 'About page'
+  }
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <h1>Welcome!</h1>
+    <NLink to="/about">
+      About Page
+    </NLink>
+  </div>
+</template>
+
+<script>
+export default {
+  head: {
+    title: 'Home page'
+  }
+}
+</script>

--- a/render.yaml
+++ b/render.yaml
@@ -5,10 +5,3 @@ services:
   plan: starter
   buildCommand: yarn; yarn build
   startCommand: yarn start
-# Uncomment the following to deploy this app as a static site on render
-# - type: web
-#   name: nuxtjs-static
-#   env: static
-#   buildCommand: yarn; yarn generate 
-#   staticPublishPath: dist
-

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+- type: web
+  name: nuxt-js
+  env: node
+  plan: starter
+  buildCommand: yarn; yarn build
+  startCommand: yarn start
+# Uncomment the following to deploy this app as a static site on render
+# - type: web
+#   name: nuxtjs-static
+#   env: static
+#   buildCommand: yarn; yarn generate 
+#   staticPublishPath: dist
+


### PR DESCRIPTION
two notes:
1) To deploy as a static site, part of the `nuxt.config.js` needs to be un-commented. We can leave it this way as a demo and let users do that themselves on their fork. Another approach would be to make another branch called `static` on this repo with the correct config, since Render lets you choose what branch to deploy from. 

2) The app at https://nuxtjs.onrender.com doesn't currently exist, and I think for the sake of longevity of examples, someone with a render email should make it. (I'm happy to make it also, if that's fine). 